### PR TITLE
chore(deps): land safe bumps and split renovate groups

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "10.0.1",
+      "version": "10.0.11",
       "commands": [
         "dotnet-ef"
       ],
       "rollForward": false
     },
     "microsoft.web.librarymanager.cli": {
-      "version": "3.0.71",
+      "version": "3.0.114",
       "commands": [
         "libman"
       ],

--- a/.cursor/rules/k7-tests.mdc
+++ b/.cursor/rules/k7-tests.mdc
@@ -1,12 +1,12 @@
 ---
-description: K7 testing conventions (NUnit, FluentAssertions, NSubstitute)
+description: K7 testing conventions (NUnit, AwesomeAssertions, NSubstitute)
 globs: tests/**
 alwaysApply: false
 ---
 
 # Testing
 
-Stack: NUnit, FluentAssertions, NSubstitute. AAA structure.
+Stack: NUnit, AwesomeAssertions, NSubstitute. AAA structure.
 
 Naming: `{ClassUnderTest}Tests`, `{Method}_Should{Expected}_When{Condition}`.
 

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -6,4 +6,4 @@ applyTo: "tests/**"
 
 Follow [docs/dev/developing.md - Testing](../../docs/dev/developing.md#testing) and [CONTRIBUTING.md](../../CONTRIBUTING.md) (tests with behavior changes).
 
-Summary: NUnit, FluentAssertions, NSubstitute; AAA; naming `{ClassUnderTest}Tests` / `{Method}_Should{Expected}_When{Condition}`; bUnit in `Clients.ComponentTests`.
+Summary: NUnit, AwesomeAssertions, NSubstitute; AAA; naming `{ClassUnderTest}Tests` / `{Method}_Should{Expected}_When{Condition}`; bUnit in `Clients.ComponentTests`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ No `Result<T>` wrapper pattern.
 
 ## Testing (`tests/**`)
 
-NUnit, FluentAssertions, NSubstitute; bUnit for critical components. Naming: `{ClassUnderTest}Tests`, `{Method}_Should{Expected}_When{Condition}`. Full project list and CI filters: [docs/dev/developing.md](docs/dev/developing.md#testing).
+NUnit, AwesomeAssertions, NSubstitute; bUnit for critical components. Naming: `{ClassUnderTest}Tests`, `{Method}_Should{Expected}_When{Condition}`. Full project list and CI filters: [docs/dev/developing.md](docs/dev/developing.md#testing).
 
 ## Git Conventions
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,20 +5,18 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AngleSharp" Version="1.5.2" />
-    <PackageVersion Include="Ardalis.GuardClauses" Version="4.2.0" />
-    <PackageVersion Include="Aspire.Hosting.Docker" Version="13.5.3" />
+    <PackageVersion Include="Ardalis.GuardClauses" Version="4.6.0" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.5.3" />
+    <!-- Transitive CVE pins (CentralPackageTransitivePinningEnabled). Not referenced directly. -->
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.11" />
     <PackageVersion Include="Blazor-ApexCharts" Version="6.1.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.7.0" />
-    <PackageVersion Include="bunit" Version="2.7.2" />
+    <PackageVersion Include="bunit" Version="2.9.0" />
     <PackageVersion Include="CommunityToolkit.Maui.MediaElement" Version="9.0.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FFMpegCore" Version="5.4.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="LibVLCSharp" Version="4.0.0-alpha-20260828-10280" />
     <PackageVersion Include="LibVLCSharp.MAUI" Version="4.0.0-alpha-20260828-10280" />
@@ -39,15 +37,12 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.6" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.12.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.30" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.30" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
@@ -64,67 +59,62 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.22.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.100" />
+    <!-- MediaElement 9 pulls Compatibility 9.0.82; pin to 10 so Windows copy targets resolve. -->
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.100" />
     <PackageVersion Include="Microsoft.Maui.Essentials" Version="10.0.100" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="MockQueryable.NSubstitute" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.TestPlatform.TestHost" Version="17.14.1" />
+    <PackageVersion Include="MockQueryable.NSubstitute" Version="10.0.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.114" />
     <PackageVersion Include="NAudio" Version="2.2.1" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" />
-    <PackageVersion Include="nunit" Version="4.0.1" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+    <PackageVersion Include="nunit" Version="4.6.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="3.10.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageVersion Include="OpenIddict.Abstractions" Version="7.2.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
-    <PackageVersion Include="OpenIddict" Version="7.2.0" />
-    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.2.0" />
-    <PackageVersion Include="OpenIddict.Client" Version="7.2.0" />
-    <PackageVersion Include="OpenIddict.Client.SystemIntegration" Version="7.2.0" />
-    <PackageVersion Include="OpenIddict.Client.SystemNetHttp" Version="7.2.0" />
-    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.2.0" />
-    <PackageVersion Include="OpenIddict.Server" Version="7.2.0" />
-    <PackageVersion Include="OpenIddict.Server.AspNetCore" Version="7.2.0" />
-    <PackageVersion Include="Respawn" Version="6.2.0" />
-    <PackageVersion Include="MessagePack" Version="3.1.7" />
-    <PackageVersion Include="MessagePack.Annotations" Version="3.1.7" />
-    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.11.10" />
-    <PackageVersion Include="SkiaSharp" Version="3.119.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.1" />
-    <PackageVersion Include="SourceGear.sqlite3" Version="3.50.4.5" />
-    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageVersion Include="SQLitePCLRaw.config.e_sqlite3" Version="3.0.3" />
-    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.3" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="OpenIddict.Abstractions" Version="7.6.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
+    <PackageVersion Include="OpenIddict" Version="7.6.1" />
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.6.1" />
+    <PackageVersion Include="OpenIddict.Client" Version="7.6.1" />
+    <PackageVersion Include="OpenIddict.Client.SystemIntegration" Version="7.6.1" />
+    <PackageVersion Include="OpenIddict.Client.SystemNetHttp" Version="7.6.1" />
+    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.6.1" />
+    <PackageVersion Include="OpenIddict.Server" Version="7.6.1" />
+    <PackageVersion Include="OpenIddict.Server.AspNetCore" Version="7.6.1" />
+    <PackageVersion Include="Respawn" Version="6.2.1" />
+    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.17.2" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.4" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.4" />
+    <PackageVersion Include="SourceGear.sqlite3" Version="3.53.4" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
+    <PackageVersion Include="SQLitePCLRaw.config.e_sqlite3" Version="3.0.5" />
+    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.5" />
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
-    <PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.5" />
+    <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="SkiaSharp.Extended.UI.Maui" Version="3.0.0" />
-    <PackageVersion Include="SkiaSharp.Skottie" Version="3.119.1" />
+    <PackageVersion Include="SkiaSharp.Skottie" Version="3.119.4" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="SharpDX.Direct3D11" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
-    <PackageVersion Include="Spectre.Console" Version="0.50.0" />
-    <PackageVersion Include="Svg.Skia" Version="3.0.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.57.2" />
+    <PackageVersion Include="Svg.Skia" Version="3.7.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.11" />
-    <PackageVersion Include="System.Drawing.Common" Version="10.0.11" />
     <PackageVersion Include="System.Text.Json" Version="10.0.11" />
     <PackageVersion Include="TagLibSharp" Version="2.3.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.14.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="TMDbLib" Version="2.3.0" />
     <PackageVersion Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20260830" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.11" />
-    <PackageVersion Include="Xamarin.GooglePlayServices.Cast" Version="122.3.1" />
-    <PackageVersion Include="Xamarin.GooglePlayServices.Cast.Framework" Version="122.3.1" />
-    <PackageVersion Include="Xamarin.GooglePlayServices.Basement" Version="118.10.0.1" />
+    <PackageVersion Include="Xamarin.GooglePlayServices.Cast" Version="122.3.1.1" />
+    <PackageVersion Include="Xamarin.GooglePlayServices.Cast.Framework" Version="122.3.1.1" />
+    <PackageVersion Include="Xamarin.GooglePlayServices.Basement" Version="118.10.0.2" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="CommunityToolkit.Maui.MediaElement" Version="9.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FFMpegCore" Version="5.4.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.6.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="LibVLCSharp" Version="4.0.0-alpha-20260828-10280" />
     <PackageVersion Include="LibVLCSharp.MAUI" Version="4.0.0-alpha-20260828-10280" />

--- a/docs/dev/developing.md
+++ b/docs/dev/developing.md
@@ -129,7 +129,7 @@ A normal `dotnet build` on `src/Server/Web` regenerates the document. Prefer sha
 
 ## Testing
 
-Stack: **NUnit**, **FluentAssertions**, **NSubstitute**. Blazor component tests use **bUnit**. Naming: `{ClassUnderTest}Tests`, `{Method}_Should{Expected}_When{Condition}`.
+Stack: **NUnit**, **AwesomeAssertions**, **NSubstitute**. Blazor component tests use **bUnit**. Naming: `{ClassUnderTest}Tests`, `{Method}_Should{Expected}_When{Condition}`.
 
 New behavior should ship with tests in the matching project (unit, bUnit, functional, or integration). Prefer covering the happy path and important failure cases for Application handlers and critical UI.
 
@@ -159,7 +159,7 @@ Functional/integration tests need **Docker** (Testcontainers.PostgreSQL + Respaw
 
 K7 uses **[Renovate](https://docs.renovatebot.com/)** (self-hosted via GitHub Actions), not Dependabot version updates. Config: [`renovate.json`](../../renovate.json). Workflow: [`.github/workflows/renovate.yml`](../../.github/workflows/renovate.yml) (weekly Monday + `workflow_dispatch`).
 
-Renovate groups only packages that must bump together (OpenIddict, OpenTelemetry, SkiaSharp, LibVLC, SQLite natives, Google Play Services, Microsoft runtime minors). Everything else gets its own PR so one breaking bump cannot block the rest. Majors for `Microsoft.OpenApi` (incompatible with `Microsoft.AspNetCore.OpenApi` 10) and `FluentAssertions` (license + API) are disabled.
+Renovate groups only packages that must bump together (OpenIddict, OpenTelemetry, SkiaSharp, LibVLC, SQLite natives, Google Play Services, Microsoft runtime minors). Everything else gets its own PR so one breaking bump cannot block the rest. Majors for `Microsoft.OpenApi` (incompatible with `Microsoft.AspNetCore.OpenApi` 10) are disabled.
 
 `Directory.Packages.props` also pins some transitive packages (`Azure.Identity`, `System.Drawing.Common`, `SSH.NET`) to patched versions. CI fails `dotnet list package --vulnerable` if those pins are removed.
 

--- a/docs/dev/developing.md
+++ b/docs/dev/developing.md
@@ -159,6 +159,8 @@ Functional/integration tests need **Docker** (Testcontainers.PostgreSQL + Respaw
 
 K7 uses **[Renovate](https://docs.renovatebot.com/)** (self-hosted via GitHub Actions), not Dependabot version updates. Config: [`renovate.json`](../../renovate.json). Workflow: [`.github/workflows/renovate.yml`](../../.github/workflows/renovate.yml) (weekly Monday + `workflow_dispatch`).
 
+Renovate groups only packages that must bump together (OpenIddict, OpenTelemetry, SkiaSharp, LibVLC, SQLite natives, Google Play Services, Microsoft runtime minors). Everything else gets its own PR so one breaking bump cannot block the rest. Majors for `Microsoft.OpenApi` (incompatible with `Microsoft.AspNetCore.OpenApi` 10) and `FluentAssertions` (license + API) are disabled.
+
 `Directory.Packages.props` also pins some transitive packages (`Azure.Identity`, `System.Drawing.Common`, `SSH.NET`) to patched versions. CI fails `dotnet list package --vulnerable` if those pins are removed.
 
 The job installs the `maui-android` workload on the runner so NuGet restore works for MAUI, including `android-arm` (Fire Stick / 32-bit). It uses the workflow `GITHUB_TOKEN` (no secret required).

--- a/docs/dev/developing.md
+++ b/docs/dev/developing.md
@@ -163,6 +163,8 @@ Renovate groups only packages that must bump together (OpenIddict, OpenTelemetry
 
 `Directory.Packages.props` also pins some transitive packages (`Azure.Identity`, `System.Drawing.Common`, `SSH.NET`) to patched versions. CI fails `dotnet list package --vulnerable` if those pins are removed.
 
+Commit messages use `chore(deps): bump <package> to vX.Y.Z`. Renovate always writes **one commit per PR** (it force-pushes that single commit when it rebases). Isolated per-package history therefore comes from ungrouped PRs, not from multiple commits inside a grouped PR.
+
 The job installs the `maui-android` workload on the runner so NuGet restore works for MAUI, including `android-arm` (Fire Stick / 32-bit). It uses the workflow `GITHUB_TOKEN` (no secret required).
 
 Repo **Settings -> Actions -> General** must allow Actions to create pull requests (write permissions). Without this, Renovate pushes branches but cannot open PRs.

--- a/docs/dev/developing.md
+++ b/docs/dev/developing.md
@@ -159,6 +159,8 @@ Functional/integration tests need **Docker** (Testcontainers.PostgreSQL + Respaw
 
 K7 uses **[Renovate](https://docs.renovatebot.com/)** (self-hosted via GitHub Actions), not Dependabot version updates. Config: [`renovate.json`](../../renovate.json). Workflow: [`.github/workflows/renovate.yml`](../../.github/workflows/renovate.yml) (weekly Monday + `workflow_dispatch`).
 
+`Directory.Packages.props` also pins some transitive packages (`Azure.Identity`, `System.Drawing.Common`, `SSH.NET`) to patched versions. CI fails `dotnet list package --vulnerable` if those pins are removed.
+
 The job installs the `maui-android` workload on the runner so NuGet restore works for MAUI, including `android-arm` (Fire Stick / 32-bit). It uses the workflow `GITHUB_TOKEN` (no secret required).
 
 Repo **Settings -> Actions -> General** must allow Actions to create pull requests (write permissions). Without this, Renovate pushes branches but cannot open PRs.

--- a/renovate.json
+++ b/renovate.json
@@ -72,12 +72,6 @@
       "enabled": false
     },
     {
-      "description": "FluentAssertions 8+ changes license and assertion APIs",
-      "matchPackageNames": ["FluentAssertions"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
-    },
-    {
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
       "groupName": "github actions"

--- a/renovate.json
+++ b/renovate.json
@@ -16,16 +16,64 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "description": "Group all other NuGet packages (CPM)",
+      "description": "Group OpenIddict packages (must bump together)",
       "matchManagers": ["nuget"],
-      "matchPackageNames": ["!/^Microsoft\\./", "!/^System\\./", "!/^Aspire\\./"],
-      "groupName": "nuget other"
+      "matchPackageNames": ["/^OpenIddict/"],
+      "groupName": "openiddict"
     },
     {
-      "description": "Group Microsoft / System / Aspire NuGet packages (CPM)",
+      "description": "Group OpenTelemetry packages",
       "matchManagers": ["nuget"],
-      "matchPackageNames": ["/^Microsoft\\./", "/^System\\./", "/^Aspire\\./"],
-      "groupName": "nuget microsoft"
+      "matchPackageNames": ["/^OpenTelemetry/"],
+      "groupName": "opentelemetry"
+    },
+    {
+      "description": "Group SkiaSharp family",
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["/^SkiaSharp/", "Svg.Skia"],
+      "groupName": "skiasharp"
+    },
+    {
+      "description": "Group LibVLCSharp alpha stack",
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["/^LibVLCSharp/", "VideoLAN.LibVLC.Windows"],
+      "groupName": "libvlc"
+    },
+    {
+      "description": "Group SQLite native pins",
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["/^SQLitePCLRaw/", "SourceGear.sqlite3"],
+      "groupName": "sqlite-native"
+    },
+    {
+      "description": "Group Google Play Services / Cast",
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["/^Xamarin.GooglePlayServices/"],
+      "groupName": "google-play-services"
+    },
+    {
+      "description": "Group ASP.NET / EF / Extensions / Aspire minors and patches only",
+      "matchManagers": ["nuget"],
+      "matchPackageNames": [
+        "/^Microsoft\\.(AspNetCore|EntityFrameworkCore|Extensions)\\./",
+        "/^System\\.(Text\\.Json|IdentityModel)/",
+        "Microsoft.IdentityModel.Protocols.OpenIdConnect",
+        "/^Aspire\\./"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "microsoft runtime"
+    },
+    {
+      "description": "Microsoft.OpenApi 3.x is incompatible with Microsoft.AspNetCore.OpenApi 10",
+      "matchPackageNames": ["Microsoft.OpenApi"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "FluentAssertions 8+ changes license and assertion APIs",
+      "matchPackageNames": ["FluentAssertions"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     },
     {
       "description": "Group GitHub Actions updates",

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,8 @@
   "prHourlyLimit": 0,
   "prCreation": "immediate",
   "rangeStrategy": "bump",
+  "commitMessageAction": "bump",
+  "commitMessageTopic": "{{depName}}",
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {

--- a/src/Clients/MAUI/K7.Clients.MAUI.csproj
+++ b/src/Clients/MAUI/K7.Clients.MAUI.csproj
@@ -98,7 +98,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Maui.Controls" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
     <PackageReference Include="Microsoft.Maui.Essentials" />

--- a/src/Server/Infrastructure/Database/Context/Identity/IdentityNoOpEmailSender.cs
+++ b/src/Server/Infrastructure/Database/Context/Identity/IdentityNoOpEmailSender.cs
@@ -1,20 +1,15 @@
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.UI.Services;
 
-namespace K7.Server.Infrastructure.Database.Context.Identity
+namespace K7.Server.Infrastructure.Database.Context.Identity;
+
+public sealed class IdentityNoOpEmailSender : IEmailSender<ApplicationUser>
 {
-    // Remove the "else if (EmailSender is IdentityNoOpEmailSender)" block from RegisterConfirmation.razor after updating with a real implementation.
-    public sealed class IdentityNoOpEmailSender : IEmailSender<ApplicationUser>
-    {
-        private readonly IEmailSender emailSender = new NoOpEmailSender();
+    public Task SendConfirmationLinkAsync(ApplicationUser user, string email, string confirmationLink) =>
+        Task.CompletedTask;
 
-        public Task SendConfirmationLinkAsync(ApplicationUser user, string email, string confirmationLink) =>
-            emailSender.SendEmailAsync(email, "Confirm your email", $"Please confirm your account by <a href='{confirmationLink}'>clicking here</a>.");
+    public Task SendPasswordResetLinkAsync(ApplicationUser user, string email, string resetLink) =>
+        Task.CompletedTask;
 
-        public Task SendPasswordResetLinkAsync(ApplicationUser user, string email, string resetLink) =>
-            emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password by <a href='{resetLink}'>clicking here</a>.");
-
-        public Task SendPasswordResetCodeAsync(ApplicationUser user, string email, string resetCode) =>
-            emailSender.SendEmailAsync(email, "Reset your password", $"Please reset your password using the following code: {resetCode}");
-    }
+    public Task SendPasswordResetCodeAsync(ApplicationUser user, string email, string resetCode) =>
+        Task.CompletedTask;
 }

--- a/src/Server/Web/K7.Server.Web.csproj
+++ b/src/Server/Web/K7.Server.Web.csproj
@@ -53,7 +53,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
-    <PackageReference Include="FluentValidation.AspNetCore" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
     <PackageReference Include="OpenIddict.AspNetCore" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" />

--- a/tests/Application.FunctionalTests/Application.FunctionalTests.csproj
+++ b/tests/Application.FunctionalTests/Application.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <RootNamespace>K7.Server.Application.FunctionalTests</RootNamespace>
@@ -15,7 +15,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
     </ItemGroup>
     
     <ItemGroup>

--- a/tests/Application.FunctionalTests/GlobalUsings.cs
+++ b/tests/Application.FunctionalTests/GlobalUsings.cs
@@ -1,3 +1,3 @@
-﻿global using Ardalis.GuardClauses;
-global using FluentAssertions;
+global using Ardalis.GuardClauses;
+global using AwesomeAssertions;
 global using NUnit.Framework;

--- a/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <RootNamespace>K7.Server.Application.UnitTests</RootNamespace>
@@ -21,7 +21,7 @@
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Application.UnitTests/Common/Mappings/PlaybackSessionDetailsMappingsTests.cs
+++ b/tests/Application.UnitTests/Common/Mappings/PlaybackSessionDetailsMappingsTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common.Mappings;
 using K7.Server.Domain.Entities.Users;
 using K7.Server.Domain.Enums;

--- a/tests/Application.UnitTests/Features/ClientAppPasswords/ClientAppPasswordServiceTests.cs
+++ b/tests/Application.UnitTests/Features/ClientAppPasswords/ClientAppPasswordServiceTests.cs
@@ -1,6 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Infrastructure.Database.Context.Services;
 using Microsoft.AspNetCore.DataProtection;
 

--- a/tests/Application.UnitTests/Features/Devices/EnsureOpenSubsonicDeviceCommandTests.cs
+++ b/tests/Application.UnitTests/Features/Devices/EnsureOpenSubsonicDeviceCommandTests.cs
@@ -1,6 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Features.Devices.Commands.EnsureOpenSubsonicDevice;
 
 namespace K7.Server.Application.UnitTests.Features.Devices;

--- a/tests/Application.UnitTests/Features/Medias/Services/MediaIdentityKeysTests.cs
+++ b/tests/Application.UnitTests/Features/Medias/Services/MediaIdentityKeysTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Features.Medias.Services;
 
 namespace K7.Server.Application.UnitTests.Features.Medias.Services;

--- a/tests/Application.UnitTests/Features/Medias/Services/MusicArtistNameNormalizerTests.cs
+++ b/tests/Application.UnitTests/Features/Medias/Services/MusicArtistNameNormalizerTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Features.Medias.Services;
 using NUnit.Framework;
 

--- a/tests/Application.UnitTests/Features/MusicIntelligence/MusicIntelligenceInstantPlaylistSettingsTests.cs
+++ b/tests/Application.UnitTests/Features/MusicIntelligence/MusicIntelligenceInstantPlaylistSettingsTests.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Shared.Dtos;
 
 namespace K7.Server.Application.UnitTests.Features.MusicIntelligence;

--- a/tests/Application.UnitTests/Features/OpenSubsonic/OpenSubsonicConstantsTests.cs
+++ b/tests/Application.UnitTests/Features/OpenSubsonic/OpenSubsonicConstantsTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Features.OpenSubsonic;
 
 namespace K7.Server.Application.UnitTests.Features.OpenSubsonic;

--- a/tests/Application.UnitTests/Features/OpenSubsonic/OpenSubsonicReportPlaybackTests.cs
+++ b/tests/Application.UnitTests/Features/OpenSubsonic/OpenSubsonicReportPlaybackTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common.Interfaces;
 using K7.Server.Application.Common.Services;
 using K7.Server.Application.Features.Devices.Commands.EnsureOpenSubsonicDevice;

--- a/tests/Application.UnitTests/Features/OpenSubsonic/OpenSubsonicScrobbleTests.cs
+++ b/tests/Application.UnitTests/Features/OpenSubsonic/OpenSubsonicScrobbleTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common.Interfaces;
 using K7.Server.Application.Common.Services;
 using K7.Server.Application.Features.Devices.Commands.EnsureOpenSubsonicDevice;

--- a/tests/Application.UnitTests/Features/OpenSubsonic/OpenSubsonicServiceTests.cs
+++ b/tests/Application.UnitTests/Features/OpenSubsonic/OpenSubsonicServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common.Interfaces;
 using K7.Server.Application.Common.Services;
 using K7.Server.Application.Features.OpenSubsonic;

--- a/tests/Application.UnitTests/Features/OpenSubsonic/OpenSubsonicStreamTranscodeTests.cs
+++ b/tests/Application.UnitTests/Features/OpenSubsonic/OpenSubsonicStreamTranscodeTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Features.OpenSubsonic;
 
 namespace K7.Server.Application.UnitTests.Features.OpenSubsonic;

--- a/tests/Application.UnitTests/Features/SharedProfiles/CreateSharedProfileCommandValidatorTests.cs
+++ b/tests/Application.UnitTests/Features/SharedProfiles/CreateSharedProfileCommandValidatorTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Features.SharedProfiles.Commands.CreateSharedProfile;
 using NUnit.Framework;
 

--- a/tests/Application.UnitTests/Features/SharedProfiles/PinHashHelperTests.cs
+++ b/tests/Application.UnitTests/Features/SharedProfiles/PinHashHelperTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common.Security;
 using NUnit.Framework;
 

--- a/tests/Application.UnitTests/Features/SharedProfiles/SharedProfilePlaybackResolverTests.cs
+++ b/tests/Application.UnitTests/Features/SharedProfiles/SharedProfilePlaybackResolverTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common.Interfaces;
 using K7.Server.Application.Services;
 using K7.Server.Domain.Entities.Users;

--- a/tests/Application.UnitTests/GlobalUsings.cs
+++ b/tests/Application.UnitTests/GlobalUsings.cs
@@ -1,3 +1,3 @@
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using NSubstitute;
 global using NUnit.Framework;

--- a/tests/Application.UnitTests/Helpers/FileSystemIoTests.cs
+++ b/tests/Application.UnitTests/Helpers/FileSystemIoTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Helpers;
 
 namespace K7.Server.Application.UnitTests.Helpers;

--- a/tests/Application.UnitTests/Helpers/Fmp4TfdtRebaseTests.cs
+++ b/tests/Application.UnitTests/Helpers/Fmp4TfdtRebaseTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Helpers;
 using K7.Server.Domain.Constants;
 

--- a/tests/Application.UnitTests/Helpers/MediaIdentityKeyTests.cs
+++ b/tests/Application.UnitTests/Helpers/MediaIdentityKeyTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Helpers;
 using K7.Server.Domain.Entities;
 using K7.Server.Domain.Enums;

--- a/tests/Application.UnitTests/Helpers/MetadataPictureLockHelperTests.cs
+++ b/tests/Application.UnitTests/Helpers/MetadataPictureLockHelperTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Domain.Enums;
 using K7.Server.Domain.Helpers;
 

--- a/tests/Application.UnitTests/Helpers/MetadataProviderHostMapperTests.cs
+++ b/tests/Application.UnitTests/Helpers/MetadataProviderHostMapperTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common;
 using K7.Server.Application.Helpers;
 using K7.Server.Domain.Enums;

--- a/tests/Application.UnitTests/ImportMediaTypeCompatibilityTests.cs
+++ b/tests/Application.UnitTests/ImportMediaTypeCompatibilityTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Domain.Enums;
 using K7.Shared;
 

--- a/tests/Application.UnitTests/Security/ApiKeyServiceTests.cs
+++ b/tests/Application.UnitTests/Security/ApiKeyServiceTests.cs
@@ -1,6 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Infrastructure.Configuration;
 using K7.Server.Infrastructure.Database.Context.Services;
 using Microsoft.Extensions.Options;

--- a/tests/Application.UnitTests/Services/ActiveStreamTrackerTests.cs
+++ b/tests/Application.UnitTests/Services/ActiveStreamTrackerTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Services;
 using K7.Server.Domain.Enums;
 using K7.Shared.Dtos;

--- a/tests/Application.UnitTests/Services/BackgroundTaskCandidateSelectorTests.cs
+++ b/tests/Application.UnitTests/Services/BackgroundTaskCandidateSelectorTests.cs
@@ -1,5 +1,5 @@
 using System.Collections.Concurrent;
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common;
 using K7.Server.Application.Services;
 using K7.Server.Domain.Constants;

--- a/tests/Application.UnitTests/Services/BackgroundTaskConcurrencyGateTests.cs
+++ b/tests/Application.UnitTests/Services/BackgroundTaskConcurrencyGateTests.cs
@@ -1,5 +1,5 @@
 using System.Collections.Concurrent;
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common;
 using K7.Server.Application.Services;
 using K7.Server.Domain.Constants;

--- a/tests/Application.UnitTests/Services/BackgroundTaskSchedulingTests.cs
+++ b/tests/Application.UnitTests/Services/BackgroundTaskSchedulingTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Domain.Constants;
 using K7.Server.Domain.Enums;
 

--- a/tests/Application.UnitTests/Services/EpisodeStillTimestampSelectorTests.cs
+++ b/tests/Application.UnitTests/Services/EpisodeStillTimestampSelectorTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common.Services;
 
 namespace K7.Server.Application.UnitTests.Services;

--- a/tests/Application.UnitTests/Services/MediaIdentityLockTests.cs
+++ b/tests/Application.UnitTests/Services/MediaIdentityLockTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Services;
 
 namespace K7.Server.Application.UnitTests.Services;

--- a/tests/Application.UnitTests/Services/MetadataProviderCooldownStoreTests.cs
+++ b/tests/Application.UnitTests/Services/MetadataProviderCooldownStoreTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Server.Application.Common;
 using K7.Server.Application.Services;
 

--- a/tests/Clients.ComponentTests/Clients.ComponentTests.csproj
+++ b/tests/Clients.ComponentTests/Clients.ComponentTests.csproj
@@ -15,7 +15,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
         <PackageReference Include="NSubstitute" />
     </ItemGroup>
 

--- a/tests/Clients.ComponentTests/Components/K7SearchSelectTests.cs
+++ b/tests/Clients.ComponentTests/Components/K7SearchSelectTests.cs
@@ -1,4 +1,3 @@
-using AngleSharp.Dom;
 using K7.Clients.Shared.UI;
 using K7.Clients.Shared.UI.Components;
 using Microsoft.AspNetCore.Components;
@@ -81,7 +80,7 @@ public class K7SearchSelectTests
             .Add(x => x.SearchAsync, (_, _) => Task.FromResult<IReadOnlyList<string>>(["Actor A"])));
 
         var input = cut.Find("input");
-        await BeginEditingAsync(input);
+        await BeginEditingAsync(cut);
         await input.InputAsync("tom");
         cut.WaitForAssertion(() => cut.FindAll(".k7-search-select-option").Count.Should().Be(1));
 
@@ -110,7 +109,7 @@ public class K7SearchSelectTests
         await input.FocusAsync();
         searchCount.Should().Be(0);
 
-        await BeginEditingAsync(input);
+        await BeginEditingAsync(cut);
         cut.WaitForAssertion(() => cut.FindAll(".k7-search-select-option").Count.Should().Be(2));
 
         searchCount.Should().Be(1);
@@ -132,7 +131,7 @@ public class K7SearchSelectTests
             }));
 
         var input = cut.Find("input");
-        await BeginEditingAsync(input);
+        await BeginEditingAsync(cut);
         searchCount.Should().Be(0);
 
         await input.InputAsync("t");
@@ -153,7 +152,7 @@ public class K7SearchSelectTests
             .Add(x => x.SearchAsync, (_, _) => Task.FromResult<IReadOnlyList<string>>(["Alpha", "Beta"])));
 
         var input = cut.Find("input");
-        await BeginEditingAsync(input);
+        await BeginEditingAsync(cut);
         await input.InputAsync("ab");
         cut.WaitForAssertion(() => cut.FindAll(".k7-search-select-option").Count.Should().Be(2));
 
@@ -177,7 +176,7 @@ public class K7SearchSelectTests
             .Add(x => x.SearchAsync, (_, _) => Task.FromResult<IReadOnlyList<string>>(["Actor A"])));
 
         var input = cut.Find("input");
-        await BeginEditingAsync(input);
+        await BeginEditingAsync(cut);
         await input.InputAsync("tom");
         cut.WaitForAssertion(() => cut.FindAll(".k7-search-select-option").Count.Should().Be(1));
 
@@ -197,7 +196,7 @@ public class K7SearchSelectTests
             .Add(x => x.SearchAsync, (_, _) => Task.FromResult<IReadOnlyList<string>>(["Actor A", "Actor B"])));
 
         var input = cut.Find("input");
-        await BeginEditingAsync(input);
+        await BeginEditingAsync(cut);
         await input.InputAsync("to");
         cut.WaitForAssertion(() => cut.FindAll(".k7-search-select-option").Count.Should().Be(2));
 
@@ -222,7 +221,7 @@ public class K7SearchSelectTests
             .Add(x => x.SearchAsync, (_, _) => Task.FromResult<IReadOnlyList<string>>(["Alpha", "Beta"])));
 
         var input = cut.Find("input");
-        await BeginEditingAsync(input);
+        await BeginEditingAsync(cut);
         await input.InputAsync("ab");
         cut.WaitForAssertion(() => cut.FindAll(".k7-search-select-option").Count.Should().Be(2));
 
@@ -255,7 +254,7 @@ public class K7SearchSelectTests
             .Add(x => x.SearchAsync, (_, _) => Task.FromResult<IReadOnlyList<string>>(["Actor A"])));
 
         var input = cut.Find("input");
-        await BeginEditingAsync(input);
+        await BeginEditingAsync(cut);
         await input.InputAsync("ac");
         cut.WaitForAssertion(() => cut.FindAll(".k7-search-select-option").Count.Should().Be(1));
 
@@ -287,7 +286,7 @@ public class K7SearchSelectTests
             .Add(x => x.SearchAsync, (_, _) => Task.FromResult<IReadOnlyList<string>>(["Actor A"])));
 
         var input = cut.Find("input");
-        await BeginEditingAsync(input);
+        await BeginEditingAsync(cut);
         await input.InputAsync("tom");
         cut.WaitForAssertion(() => cut.FindAll(".k7-search-select-option").Count.Should().Be(1));
 
@@ -312,8 +311,6 @@ public class K7SearchSelectTests
         return ctx;
     }
 
-    private static async Task BeginEditingAsync(IElement input)
-    {
-        await input.KeyDownAsync("Enter");
-    }
+    private static Task BeginEditingAsync(IRenderedComponent<K7SearchSelect> cut) =>
+        cut.Find("input").KeyDownAsync("Enter");
 }

--- a/tests/Clients.ComponentTests/GlobalUsings.cs
+++ b/tests/Clients.ComponentTests/GlobalUsings.cs
@@ -1,4 +1,4 @@
 global using NUnit.Framework;
 global using Bunit;
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using NSubstitute;

--- a/tests/Clients.ComponentTests/Helpers/ExoPlaybackStateMappingTests.cs
+++ b/tests/Clients.ComponentTests/Helpers/ExoPlaybackStateMappingTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.Shared.Helpers;
 using K7.Server.Domain.Enums;
 

--- a/tests/Clients.ComponentTests/Helpers/LibVlcWindowsCapabilitiesTests.cs
+++ b/tests/Clients.ComponentTests/Helpers/LibVlcWindowsCapabilitiesTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.Shared.Helpers;
 
 namespace K7.Clients.ComponentTests.Helpers;

--- a/tests/Clients.ComponentTests/Helpers/LocalPlaybackUrlTests.cs
+++ b/tests/Clients.ComponentTests/Helpers/LocalPlaybackUrlTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.Shared.Helpers;
 
 namespace K7.Clients.ComponentTests.Helpers;

--- a/tests/Clients.ComponentTests/Helpers/NativeSeekThumbnailHelperTests.cs
+++ b/tests/Clients.ComponentTests/Helpers/NativeSeekThumbnailHelperTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.Shared.Helpers;
 
 namespace K7.Clients.ComponentTests.Helpers;

--- a/tests/Clients.ComponentTests/Helpers/NativeSettingsFocusNavigatorTests.cs
+++ b/tests/Clients.ComponentTests/Helpers/NativeSettingsFocusNavigatorTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.Shared.Helpers;
 
 namespace K7.Clients.ComponentTests.Helpers;

--- a/tests/Clients.ComponentTests/Helpers/NativeVideoBackStackTests.cs
+++ b/tests/Clients.ComponentTests/Helpers/NativeVideoBackStackTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.Shared.Helpers;
 using K7.Server.Domain.Enums;
 

--- a/tests/Clients.ComponentTests/Helpers/NativeVideoPlaybackEndTests.cs
+++ b/tests/Clients.ComponentTests/Helpers/NativeVideoPlaybackEndTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.Shared.Helpers;
 using K7.Server.Domain.Enums;
 

--- a/tests/Clients.ComponentTests/Helpers/StreamingSourceKindTests.cs
+++ b/tests/Clients.ComponentTests/Helpers/StreamingSourceKindTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.Shared.Helpers;
 
 namespace K7.Clients.ComponentTests.Helpers;

--- a/tests/Clients.ComponentTests/Helpers/VideoRemoteTransportKeysTests.cs
+++ b/tests/Clients.ComponentTests/Helpers/VideoRemoteTransportKeysTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.Shared.Helpers;
 
 namespace K7.Clients.ComponentTests.Helpers;

--- a/tests/Clients.ComponentTests/Models/VideoQualityOptionTests.cs
+++ b/tests/Clients.ComponentTests/Models/VideoQualityOptionTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.Shared.Models;
 using K7.Server.Domain.Enums;
 using NUnit.Framework;

--- a/tests/Clients.ComponentTests/PreferenceKeyCatalogTests.cs
+++ b/tests/Clients.ComponentTests/PreferenceKeyCatalogTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Shared;
 
 namespace K7.Clients.ComponentTests;

--- a/tests/Clients.DesignSystem.SmokeTests/Clients.DesignSystem.SmokeTests.csproj
+++ b/tests/Clients.DesignSystem.SmokeTests/Clients.DesignSystem.SmokeTests.csproj
@@ -15,7 +15,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Clients.DesignSystem.SmokeTests/GlobalUsings.cs
+++ b/tests/Clients.DesignSystem.SmokeTests/GlobalUsings.cs
@@ -1,2 +1,2 @@
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using NUnit.Framework;

--- a/tests/Clients.MAUI.SmokeTests/Clients.MAUI.SmokeTests.csproj
+++ b/tests/Clients.MAUI.SmokeTests/Clients.MAUI.SmokeTests.csproj
@@ -19,7 +19,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Clients.MAUI.SmokeTests/GlobalUsings.cs
+++ b/tests/Clients.MAUI.SmokeTests/GlobalUsings.cs
@@ -1,2 +1,2 @@
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using NUnit.Framework;

--- a/tests/Clients.MAUI.SmokeTests/VlcAuthProxyHlsMasterTests.cs
+++ b/tests/Clients.MAUI.SmokeTests/VlcAuthProxyHlsMasterTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using K7.Clients.MAUI.Playback;
 
 namespace K7.Clients.MAUI.SmokeTests;

--- a/tests/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/tests/Domain.UnitTests/Domain.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <RootNamespace>K7.Server.Domain.UnitTests</RootNamespace>
@@ -14,7 +14,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Domain.UnitTests/GlobalUsings.cs
+++ b/tests/Domain.UnitTests/GlobalUsings.cs
@@ -1,2 +1,2 @@
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using NUnit.Framework;

--- a/tests/Import.UnitTests/GlobalUsings.cs
+++ b/tests/Import.UnitTests/GlobalUsings.cs
@@ -1,2 +1,2 @@
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using NUnit.Framework;

--- a/tests/Import.UnitTests/Import.UnitTests.csproj
+++ b/tests/Import.UnitTests/Import.UnitTests.csproj
@@ -14,7 +14,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Infrastructure.IntegrationTests/GlobalUsings.cs
+++ b/tests/Infrastructure.IntegrationTests/GlobalUsings.cs
@@ -1,2 +1,2 @@
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using NUnit.Framework;

--- a/tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj
+++ b/tests/Infrastructure.IntegrationTests/Infrastructure.IntegrationTests.csproj
@@ -14,7 +14,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
     </ItemGroup>
 

--- a/tests/Tests.Helpers/Tests.Helpers.csproj
+++ b/tests/Tests.Helpers/Tests.Helpers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <RootNamespace>K7.Tests.Helpers</RootNamespace>
@@ -20,7 +20,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
         <PackageReference Include="Respawn" />
         <PackageReference Include="Testcontainers.PostgreSql" />
         <!-- Force patched SSH.NET; Testcontainers still resolves an older vulnerable transitive. -->

--- a/tests/Web.SmokeTests/GlobalUsings.cs
+++ b/tests/Web.SmokeTests/GlobalUsings.cs
@@ -1,2 +1,2 @@
-global using FluentAssertions;
+global using AwesomeAssertions;
 global using NUnit.Framework;

--- a/tests/Web.SmokeTests/Web.SmokeTests.csproj
+++ b/tests/Web.SmokeTests/Web.SmokeTests.csproj
@@ -14,7 +14,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Lands the easy minor/patch NuGet and tool bumps from the blocked Renovate PRs, without MediatR 12.5 (breaks `RequestHandlerDelegate` in tests).
- Drops unused CPM pins leftover from the template (SQL Server, Identity.UI, FluentValidation.AspNetCore, MAUI Compatibility, Azure.Identity, MessagePack, etc.).
- Splits Renovate into tight must-bump-together groups so one breaking update cannot block the rest. Disables `Microsoft.OpenApi` 3.x and `FluentAssertions` 8+ majors.

Supersedes #49, #51, and #52.

## Test plan
- [ ] CI `build-and-test` is green
- [ ] Identity still registers (`IdentityNoOpEmailSender` no-ops email)
- [ ] After merge, run **Actions -> Renovate -> Run workflow** so the old grouped branches are recreated as smaller PRs
- [ ] Confirm leftover majors (MediatR 12.5/14, TMDbLib 3, SkiaSharp 4, FluentAssertions 8, Test.Sdk 18) appear as isolated PRs
