### PR TITLE
ci: fan-out jobs and dispatch renovate checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ on:
       - LICENSE
       - .github/FUNDING.yml
 
-  # pull_request is skipped for PRs opened by github-actions[bot] (Renovate with GITHUB_TOKEN).
-  # pull_request_target runs on opened/reopened but not reliably on synchronize; push to renovate/**
-  # triggers CI when Renovate updates dependency branches.
+  # pull_request / push from GITHUB_TOKEN (Renovate) do not start workflows.
+  # renovate.yml dispatches this workflow on renovate/* branches instead.
+  # pull_request_target remains as a fallback for Dependabot.
   pull_request_target:
     branches: [ main ]
     paths-ignore:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ env:
   IMAGE_NAME: ghcr.io/kaybi-gh/k7
 
 jobs:
+  # build-and-test is the gate. Heavier jobs start only if it succeeds.
   build-and-test:
     if: |
       github.event_name != 'pull_request_target' ||
@@ -105,6 +106,7 @@ jobs:
           dotnet test tests/Clients.DesignSystem.SmokeTests/Clients.DesignSystem.SmokeTests.csproj --configuration Release --no-build --verbosity normal
 
   maui-smoke:
+    needs: build-and-test
     if: |
       github.event_name != 'pull_request_target' ||
       contains(fromJson('["github-actions[bot]","dependabot[bot]"]'), github.event.pull_request.user.login)
@@ -154,6 +156,29 @@ jobs:
           -f net10.0-windows10.0.19041.0
           --no-build
           --verbosity normal
+
+  integration:
+    name: Integration tests
+    needs: build-and-test
+    if: |
+      github.event_name != 'pull_request_target' ||
+      contains(fromJson('["github-actions[bot]","dependabot[bot]"]'), github.event.pull_request.user.login)
+    permissions:
+      contents: read
+    uses: ./.github/workflows/integration-tests.yml
+
+  codeql:
+    name: CodeQL
+    needs: build-and-test
+    if: |
+      (github.event_name != 'pull_request_target' ||
+      contains(fromJson('["github-actions[bot]","dependabot[bot]"]'), github.event.pull_request.user.login))
+      && (github.event_name != 'push' || github.ref == 'refs/heads/main')
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    uses: ./.github/workflows/codeql.yml
 
   publish-image:
     needs: build-and-test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,18 +1,9 @@
+# PR and push analysis is invoked from build.yml after build-and-test.
+# schedule and workflow_dispatch keep a standalone weekly / manual path.
 name: CodeQL
 
 on:
-  push:
-    branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - branding/**
-      - screenshots/**
-  pull_request:
-    branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - branding/**
-      - screenshots/**
+  workflow_call:
   schedule:
     - cron: '17 4 * * 1'
   workflow_dispatch:
@@ -32,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,7 @@ on:
       - screenshots/**
   schedule:
     - cron: '17 4 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,30 +1,8 @@
+# Called from build.yml after build-and-test. workflow_dispatch keeps a manual-only path.
 name: Integration Tests
 
 on:
-  push:
-    branches: [ main, 'renovate/**' ]
-    paths-ignore:
-      - '**.md'
-      - branding/**
-      - screenshots/**
-      - LICENSE
-      - .github/FUNDING.yml
-  pull_request:
-    branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - branding/**
-      - screenshots/**
-      - LICENSE
-      - .github/FUNDING.yml
-  pull_request_target:
-    branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - branding/**
-      - screenshots/**
-      - LICENSE
-      - .github/FUNDING.yml
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -32,9 +10,6 @@ permissions:
 
 jobs:
   integration:
-    if: |
-      github.event_name != 'pull_request_target' ||
-      contains(fromJson('["github-actions[bot]","dependabot[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,7 +4,8 @@
 #
 # Uses the workflow GITHUB_TOKEN for git push and PR creation.
 # GitHub does not start workflows from GITHUB_TOKEN push/PR events, so this job
-# dispatches Build / Integration Tests / CodeQL on renovate/* PRs that have no checks.
+# dispatches Build on renovate/* PRs that have no checks. Integration tests and
+# CodeQL are jobs in that workflow and start only after build-and-test succeeds.
 # See docs/dev/developing.md#dependency-updates
 
 name: Renovate
@@ -91,6 +92,4 @@ jobs:
                 fi
                 echo "Dispatch CI for #${number} (${branch})"
                 gh workflow run Build --ref "${branch}"
-                gh workflow run "Integration Tests" --ref "${branch}"
-                gh workflow run CodeQL --ref "${branch}"
               done

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,8 +3,8 @@
 # and android-arm / Fire Stick RIDs restore correctly.
 #
 # Uses the workflow GITHUB_TOKEN for git push and PR creation.
-# CI on Renovate PRs is handled via pull_request_target in build/integration-tests workflows
-# (pull_request does not run for PRs opened by github-actions[bot]).
+# GitHub does not start workflows from GITHUB_TOKEN push/PR events, so this job
+# dispatches Build / Integration Tests / CodeQL on renovate/* PRs that have no checks.
 # See docs/dev/developing.md#dependency-updates
 
 name: Renovate
@@ -23,6 +23,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  actions: write
 
 jobs:
   renovate:
@@ -73,3 +74,23 @@ jobs:
             grep -E "^(ERROR| WARN: Error updating branch)|Pull request creation error" renovate.log || true
             exit 1
           fi
+
+      - name: Trigger CI on Renovate PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh pr list --author "app/github-actions" --state open --limit 50 \
+            --json number,headRefName,headRefOid \
+            --jq '.[] | select(.headRefName | startswith("renovate/")) | [.number, .headRefName, .headRefOid] | @tsv' \
+            | while IFS=$'\t' read -r number branch sha; do
+                count="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${sha}/check-runs" --jq '.total_count')"
+                if [ "${count}" -gt 0 ]; then
+                  echo "Skip #${number} (${branch}): ${count} check-runs already"
+                  continue
+                fi
+                echo "Dispatch CI for #${number} (${branch})"
+                gh workflow run Build --ref "${branch}"
+                gh workflow run "Integration Tests" --ref "${branch}"
+                gh workflow run CodeQL --ref "${branch}"
+              done

--- a/docs/dev/developing.md
+++ b/docs/dev/developing.md
@@ -140,8 +140,8 @@ New behavior should ship with tests in the matching project (unit, bUnit, functi
 | `Domain.UnitTests` / `Application.UnitTests` / `Import.UnitTests` | Unit | `build.yml` (fast) |
 | `Clients.ComponentTests` | bUnit | fast |
 | `Web.SmokeTests` / `Clients.DesignSystem.SmokeTests` | Smoke | fast |
-| `Clients.MAUI.SmokeTests` | MAUI smoke | `maui-smoke` (Windows) |
-| `Application.FunctionalTests` / `Infrastructure.IntegrationTests` | HTTP + EF | `integration-tests.yml` |
+| `Clients.MAUI.SmokeTests` | MAUI smoke | `build.yml` `maui-smoke` (Windows, after `build-and-test`) |
+| `Application.FunctionalTests` / `Infrastructure.IntegrationTests` | HTTP + EF | `build.yml` `integration` (after `build-and-test`) |
 | `Tests.Helpers` | Factories, Testcontainers | referenced |
 
 [`K7.CI.slnf`](../../K7.CI.slnf) is the **fast CI** filter (excludes MAUI, Aspire AppHost, functional and integration tests).
@@ -154,6 +154,10 @@ dotnet test K7.CI.slnf
 ```
 
 Functional/integration tests need **Docker** (Testcontainers.PostgreSQL + Respawn). Without Docker, unit and bUnit projects still run.
+
+`build.yml` runs `build-and-test` first (restore, vulnerable-package check, Release build of `K7.CI.slnf`, fast tests). `maui-smoke`, integration tests, CodeQL, and `publish-image` start only if that job succeeds. CodeQL still has a weekly schedule (and a manual `workflow_dispatch`) in [`codeql.yml`](../../.github/workflows/codeql.yml).
+
+If branch protection requires status checks, use the names under the **Build** workflow (`build-and-test`, `maui-smoke`, `Integration tests / integration`, `CodeQL / Analyze (csharp)`, `publish-image`). The old standalone **Integration Tests** and **CodeQL** PR checks no longer run on push/PR.
 
 ## Dependency updates
 
@@ -169,7 +173,7 @@ The job installs the `maui-android` workload on the runner so NuGet restore work
 
 Repo **Settings -> Actions -> General** must allow Actions to create pull requests (write permissions). Without this, Renovate pushes branches but cannot open PRs.
 
-GitHub does not start workflows from events created by `GITHUB_TOKEN` (push, `pull_request`, or `pull_request_target`). After Renovate opens or updates PRs, the Renovate job dispatches Build, Integration Tests, and CodeQL on any `renovate/*` head that still has no check runs. `workflow_dispatch` and `repository_dispatch` are the exceptions GitHub allows with `GITHUB_TOKEN`.
+GitHub does not start workflows from events created by `GITHUB_TOKEN` (push, `pull_request`, or `pull_request_target`). After Renovate opens or updates PRs, the Renovate job dispatches **Build** on any `renovate/*` head that still has no check runs (integration tests and CodeQL are jobs in that workflow). `workflow_dispatch` and `repository_dispatch` are the exceptions GitHub allows with `GITHUB_TOKEN`.
 
 Run **Actions -> Renovate -> Run workflow** once to verify after changing Renovate config.
 

--- a/docs/dev/developing.md
+++ b/docs/dev/developing.md
@@ -169,7 +169,7 @@ The job installs the `maui-android` workload on the runner so NuGet restore work
 
 Repo **Settings -> Actions -> General** must allow Actions to create pull requests (write permissions). Without this, Renovate pushes branches but cannot open PRs.
 
-`pull_request` CI does not run on PRs opened by `github-actions[bot]`. Build and integration-tests workflows also listen on `pull_request_target` for bot PRs (Renovate, Dependabot).
+GitHub does not start workflows from events created by `GITHUB_TOKEN` (push, `pull_request`, or `pull_request_target`). After Renovate opens or updates PRs, the Renovate job dispatches Build, Integration Tests, and CodeQL on any `renovate/*` head that still has no check runs. `workflow_dispatch` and `repository_dispatch` are the exceptions GitHub allows with `GITHUB_TOKEN`.
 
 Run **Actions -> Renovate -> Run workflow** once to verify after changing Renovate config.
 


### PR DESCRIPTION
## Summary
- `build-and-test` is now the gate. MAUI smoke, integration tests, CodeQL, and the Docker image start only if it succeeds.
- Two compiles stay (CI tests vs CodeQL). The second CodeQL build no longer starts when the gate is already red.
- GitHub does not start workflows from `GITHUB_TOKEN` events, so Renovate PRs had no checks. After each Renovate run, dispatch **Build** on any open `renovate/*` PR that still has no check runs.
- Docs no longer say `pull_request_target` was enough.

## Test plan
- [x] On a normal PR, confirm heavier jobs stay skipped if `build-and-test` fails
- [x] On a green PR, confirm MAUI, integration, CodeQL, and `publish-image` run in parallel after the gate
- [x] Merge this, then run Actions -> Renovate once (or wait for the next scheduled run)
- [x] A `renovate/*` PR with no checks should get **Build** only (not standalone Integration Tests or CodeQL)
- [x] A PR that already has check runs should be skipped (no duplicate dispatch)