### PR TITLE
Fix three iOS-only bugs: build error, startup crash, and login threading

### DIFF
--- a/src/Clients/MAUI/Platforms/iOS/BlazorPage.iOS.cs
+++ b/src/Clients/MAUI/Platforms/iOS/BlazorPage.iOS.cs
@@ -1,0 +1,26 @@
+#if IOS
+using WebKit;
+
+namespace K7.Clients.MAUI;
+
+public partial class BlazorPage
+{
+    // iOS BlazorWebView is backed by a WKWebView. Mirrors the Android/Windows
+    // TryEvaluateWebViewJs so shared native-video/overlay code compiles for iOS.
+    internal bool TryEvaluateWebViewJs(string script)
+    {
+        try
+        {
+            if (blazorWebView.Handler?.PlatformView is not WKWebView webView)
+                return false;
+
+            _ = webView.EvaluateJavaScriptAsync(script);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}
+#endif

--- a/src/Clients/MAUI/Platforms/iOS/Services/NativeAudioService.cs
+++ b/src/Clients/MAUI/Platforms/iOS/Services/NativeAudioService.cs
@@ -225,7 +225,7 @@ public class NativeAudioService : NSObject, IDisposable
             var handoffSeconds = _crossfadePlayer.CurrentTime.Seconds;
             await MainThread.InvokeOnMainThreadAsync(() => ApplySource(_player, source, 0f, observe: true));
             if (handoffSeconds > 0)
-                await MainThread.InvokeOnMainThreadAsync(() => _player.Seek(CMTime.FromSeconds(handoffSeconds, 1)));
+                await MainThread.InvokeOnMainThreadAsync(() => _player.Seek(CMTime.FromSeconds(handoffSeconds, 1000)));
 
             await WaitUntilItemReadyAsync(_player, ct);
 
@@ -356,7 +356,7 @@ public class NativeAudioService : NSObject, IDisposable
     {
         if (_player is null) return;
 
-        var interval = CMTime.FromSeconds(0.5, 1);
+        var interval = CMTime.FromSeconds(0.5, 1000);
         _timeObserver = _player.AddPeriodicTimeObserver(interval, null, time =>
         {
             _updatingFromPlayer = true;
@@ -405,7 +405,7 @@ public class NativeAudioService : NSObject, IDisposable
     {
         if (_updatingFromPlayer) return Task.CompletedTask;
         MainThread.BeginInvokeOnMainThread(() =>
-            _player?.Seek(CMTime.FromSeconds(positionSeconds, 1)));
+            _player?.Seek(CMTime.FromSeconds(positionSeconds, 1000)));
         return Task.CompletedTask;
     }
 

--- a/src/Clients/MAUI/Services/Authentication/CustomAuthenticationStateProvider.cs
+++ b/src/Clients/MAUI/Services/Authentication/CustomAuthenticationStateProvider.cs
@@ -148,9 +148,13 @@ public class CustomAuthenticationStateProvider : AuthenticationStateProvider, IC
 
         try
         {
-            // Run interactive auth off the Blazor sync context so the WebView UI
-            // stays responsive while the system browser completes the redirect.
-            await Task.Run(async () =>
+            // The interactive flow presents the system browser for sign-in. On iOS/Mac
+            // Catalyst that is an ASWebAuthenticationSession (UIKit), which MUST be started
+            // on the main thread. Running it via Task.Run presents it from a threadpool
+            // thread and raises "UIKit Consistency error: you are calling a UIKit method
+            // that can only be invoked from the UI thread." The flow is fully async and
+            // yields to the run loop, so presenting on the main thread does not freeze the UI.
+            async Task RunInteractiveLoginAsync()
             {
                 var challenge = await _openIddictClientService.ChallengeInteractivelyAsync(new()
                 {
@@ -201,7 +205,17 @@ public class CustomAuthenticationStateProvider : AuthenticationStateProvider, IC
                     await SaveLocalUserFromCurrentUserAsync(timeout.Token).ConfigureAwait(false);
                     await TryAttachCurrentUserToDeviceAsync(timeout.Token).ConfigureAwait(false);
                 }
-            }, timeout.Token).ConfigureAwait(false);
+            }
+
+#if IOS || MACCATALYST
+            await Microsoft.Maui.ApplicationModel.MainThread
+                .InvokeOnMainThreadAsync(RunInteractiveLoginAsync)
+                .ConfigureAwait(false);
+#else
+            // Other platforms: run off the Blazor sync context so the WebView UI stays
+            // responsive while the system browser completes the redirect.
+            await Task.Run(RunInteractiveLoginAsync, timeout.Token).ConfigureAwait(false);
+#endif
 
             NativeAuthTrace.Write(
                 "login-complete",


### PR DESCRIPTION
> [!WARNING]
> **This diff was written by an LLM, not by hand.** I drove the process and
> tested the result on a real device (the app builds, launches, signs in, and
> plays media on iOS 26.5.2), but I did not author the code line by line. Please
> review it as AI-generated: check the reasoning rather than trusting it.

## What this fixes

The MAUI client's iOS target has code the CI never builds (the release
workflow only targets Android and Windows), so a few iOS-only bugs stayed
hidden. I built the iOS head on a macOS runner and ran it on a physical
iPhone (iOS 26.5.2). Three bugs showed up, one blocking the next. This PR
fixes all three.

### 1. Missing `TryEvaluateWebViewJs` for iOS (build error)

`BlazorPage` calls `TryEvaluateWebViewJs` from code guarded by
`#if ANDROID || IOS || WINDOWS`, but only the Android and Windows partials
implement it. There was no iOS partial, so the iOS build fails to compile
(`CS0103`).

Added `Platforms/iOS/BlazorPage.iOS.cs`, mirroring the other platforms. On
iOS the BlazorWebView is backed by a `WKWebView`, so it takes the native
view and calls `EvaluateJavaScriptAsync`.

### 2. Startup crash from an invalid AVPlayer time observer

`NativeAudioService` created its periodic time observer with
`CMTime.FromSeconds(0.5, 1)`. A timescale of 1 cannot represent half a
second, so the interval collapses to 0. iOS 26's AVFoundation rejects a
zero interval (`invalid parameter not satisfying:
CMTimeCompare(interval, kCMTimeZero) > 0`) and throws
`NSInvalidArgumentException`. The service singleton is resolved eagerly in
`AppDelegate`, so the app aborts on launch before any UI appears.

Changed the timescale to 1000 so 0.5s is represented exactly. Also fixed
two `Seek` calls that used timescale 1 and were truncating seek targets to
whole seconds.

### 3. Login raised a UIKit threading error

`LoginAsync` ran the whole interactive OpenIddict flow inside `Task.Run`.
On iOS the interactive flow presents an `ASWebAuthenticationSession`, which
UIKit requires to start on the main thread. Presenting it from a threadpool
thread raised "UIKit Consistency error: you are calling a UIKit method that
can only be invoked from the UI thread", and sign-in never opened.

On iOS and Mac Catalyst the flow now runs through
`MainThread.InvokeOnMainThreadAsync`. It is async and yields to the run
loop, so the UI stays responsive. Other platforms keep `Task.Run`.

## Testing

Built on a GitHub Actions macOS runner and installed on a physical iPhone
(iOS 26.5.2). After these fixes the app launches, the login flow opens the
system browser and completes, and the client reaches media playback.

## Scope

This is app-code only. The tooling I used to package and sideload the build
(CI workflow, signing, bundle metadata) is specific to my setup and is left
out.
